### PR TITLE
Fix: Path load node_modules bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you want a specific version, use the following syntax: `npm install mjml@4.7.
 <?php
 require_once 'vendor/autoload.php';
 
-$renderer = new \Qferrer\Mjml\Renderer\BinaryRenderer(getcwd() . '/node_modules/.bin/mjml');
+$renderer = new \Qferrer\Mjml\Renderer\BinaryRenderer();
 
 $html = $renderer->render('
     <mjml>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-MJML in PHP
-===========
+# MJML in PHP
 
 ![PHPUnit](https://github.com/qferr/mjml-php/actions/workflows/php.yml/badge.svg)
 
 A simple PHP library to render MJML to HTML.
 
 There are two ways for integrating MJML in PHP:
-* using the MJML API
-* using the MJML library
+
+- using the MJML API
+- using the MJML library
 
 ### Installation
 
@@ -29,7 +29,7 @@ If you want a specific version, use the following syntax: `npm install mjml@4.7.
 <?php
 require_once 'vendor/autoload.php';
 
-$renderer = new \Qferrer\Mjml\Renderer\BinaryRenderer(__DIR__ . '/node_modules/.bin/mjml');
+$renderer = new \Qferrer\Mjml\Renderer\BinaryRenderer(getcwd() . '/node_modules/.bin/mjml');
 
 $html = $renderer->render('
     <mjml>

--- a/src/Renderer/BinaryRenderer.php
+++ b/src/Renderer/BinaryRenderer.php
@@ -36,8 +36,9 @@ class BinaryRenderer implements RendererInterface
     /**
      * @inheritDoc
      */
-    public function render(string $content): string
+    public function render(string $content = null): string
     {
+        if (empty($content)) $content = getcwd() . '/node_modules/.bin/mjml';
         $process = new Process($this->command, $content);
         $process->run();
 


### PR DESCRIPTION
getcwd returns the path of the folder, normally it is the best path for those who want to work with frameworks or run via docker