### PR TITLE
PHP 8.5 support

### DIFF
--- a/src/Http/Curl.php
+++ b/src/Http/Curl.php
@@ -24,8 +24,6 @@ class Curl implements CurlInterface
 
         $response = new CurlResponse($data, curl_getinfo($request, CURLINFO_HTTP_CODE));
 
-        curl_close($request);
-
         return $response;
     }
 }


### PR DESCRIPTION
PHP 8.5 deprecation warning
Remove unnecessary curl_close in Curl.php